### PR TITLE
String offset with curly braces is depreciated

### DIFF
--- a/src/RedisSMQUtils.php
+++ b/src/RedisSMQUtils.php
@@ -31,7 +31,7 @@ class RedisSMQUtils
         $possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
         for($i=0; $i < $len; $i++){
-            $text .= $possible{(int) floor(rand(0, strlen($possible) - 1))};
+            $text .= $possible[(int) floor(rand(0, strlen($possible) - 1))];
         }
         return $text;
     }


### PR DESCRIPTION
Array or string offset access with curly braces deprecated in PHP 7.4. Targeting PHP 8.1.0. Changing to brackets.